### PR TITLE
refactor: separate clients

### DIFF
--- a/pkg/clients/denonavr/denonavrclient.go
+++ b/pkg/clients/denonavr/denonavrclient.go
@@ -1,4 +1,4 @@
-package client
+package denonavrclient
 
 import (
 	"strconv"
@@ -12,7 +12,7 @@ import (
 
 // Denon AVR Client Implementation
 type DenonAVRClient struct {
-	Client
+	integration.Client
 	denon *denonavr.DenonAVR
 
 	moni1Button    *entities.ButtonEntity
@@ -31,7 +31,7 @@ func NewDenonAVRClient(i *integration.Integration) *DenonAVRClient {
 	// Start without a connection
 	client.DeviceState = integration.DisconnectedDeviceState
 
-	client.messages = make(chan string)
+	client.Messages = make(chan string)
 
 	inputSetting := integration.SetupDataSchemaSettings{
 		Id: "ipaddr",
@@ -53,7 +53,7 @@ func NewDenonAVRClient(i *integration.Integration) *DenonAVRClient {
 		Name: integration.LanguageText{
 			En: "Denon AVR",
 		},
-		Version: "0.0.1",
+		Version: "0.2.0",
 		SetupDataSchema: integration.SetupDataSchema{
 			Title: integration.LanguageText{
 				En: "Configuration",
@@ -67,9 +67,9 @@ func NewDenonAVRClient(i *integration.Integration) *DenonAVRClient {
 	client.IntegrationDriver.SetMetadata(&metadata)
 
 	// set the client specific functions
-	client.initFunc = client.initDenonAVRClient
-	client.setupFunc = client.denonHandleSetup
-	client.clientLoopFunc = client.denonClientLoop
+	client.InitFunc = client.initDenonAVRClient
+	client.SetupFunc = client.denonHandleSetup
+	client.ClientLoopFunc = client.denonClientLoop
 
 	client.mapOnState = map[bool]entities.MediaPlayerEntityState{
 		true:  entities.OnMediaPlayerEntityState,
@@ -269,7 +269,7 @@ func (c *DenonAVRClient) configureDenon() {
 func (c *DenonAVRClient) denonClientLoop() {
 
 	defer func() {
-		c.setDeviceState(integration.DisconnectedDeviceState)
+		c.SetDeviceState(integration.DisconnectedDeviceState)
 	}()
 
 	if c.denon == nil {
@@ -291,12 +291,12 @@ func (c *DenonAVRClient) denonClientLoop() {
 
 		// Handle connection to device this integration shall control
 		// Set Device state to connected when connection is established
-		c.setDeviceState(integration.ConnectedDeviceState)
+		c.SetDeviceState(integration.ConnectedDeviceState)
 	}
 
 	// Run Client Loop to handle entity changes from device
 	for {
-		msg := <-c.messages
+		msg := <-c.Messages
 		switch msg {
 		case "disconnect":
 			return

--- a/pkg/cmd/deconz/deconz.go
+++ b/pkg/cmd/deconz/deconz.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/splattner/goucrt/pkg/client"
+	deconzclient "github.com/splattner/goucrt/pkg/clients/deconz"
 	"github.com/splattner/goucrt/pkg/cmd"
 	"github.com/splattner/goucrt/pkg/integration"
 )
@@ -37,7 +37,7 @@ func NewCommand(rootCmd *cobra.Command) *cobra.Command {
 			i, err := integration.NewIntegration(config)
 			cmd.CheckError(err)
 
-			myclient := client.NewDeconzClient(i)
+			myclient := deconzclient.NewDeconzClient(i)
 
 			myclient.InitClient()
 

--- a/pkg/cmd/denonavr/denonavr.go
+++ b/pkg/cmd/denonavr/denonavr.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/splattner/goucrt/pkg/client"
+	denonavrclient "github.com/splattner/goucrt/pkg/clients/denonavr"
 	"github.com/splattner/goucrt/pkg/cmd"
 	"github.com/splattner/goucrt/pkg/integration"
 )
@@ -37,7 +37,7 @@ func NewCommand(rootCmd *cobra.Command) *cobra.Command {
 			i, err := integration.NewIntegration(config)
 			cmd.CheckError(err)
 
-			myclient := client.NewDenonAVRClient(i)
+			myclient := denonavrclient.NewDenonAVRClient(i)
 
 			myclient.InitClient()
 

--- a/pkg/cmd/shelly/shelly.go
+++ b/pkg/cmd/shelly/shelly.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/splattner/goucrt/pkg/client"
+	shellyclient "github.com/splattner/goucrt/pkg/clients/shelly"
 	"github.com/splattner/goucrt/pkg/cmd"
 	"github.com/splattner/goucrt/pkg/integration"
 )
@@ -37,7 +37,7 @@ func NewCommand(rootCmd *cobra.Command) *cobra.Command {
 			i, err := integration.NewIntegration(config)
 			cmd.CheckError(err)
 
-			myclient := client.NewShellyClient(i)
+			myclient := shellyclient.NewShellyClient(i)
 
 			myclient.InitClient()
 

--- a/pkg/cmd/tasmota/tasmota.go
+++ b/pkg/cmd/tasmota/tasmota.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/splattner/goucrt/pkg/client"
+	tasmotaclient "github.com/splattner/goucrt/pkg/clients/tasmota"
 	"github.com/splattner/goucrt/pkg/cmd"
 	"github.com/splattner/goucrt/pkg/integration"
 )
@@ -37,7 +37,7 @@ func NewCommand(rootCmd *cobra.Command) *cobra.Command {
 			i, err := integration.NewIntegration(config)
 			cmd.CheckError(err)
 
-			myclient := client.NewTasmotaClient(i)
+			myclient := tasmotaclient.NewTasmotaClient(i)
 
 			myclient.InitClient()
 

--- a/pkg/integration/client.go
+++ b/pkg/integration/client.go
@@ -1,41 +1,39 @@
-package client
+package integration
 
 import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-
-	"github.com/splattner/goucrt/pkg/integration"
 )
 
 // Generic client
 type Client struct {
-	IntegrationDriver *integration.Integration
+	IntegrationDriver *Integration
 
-	DeviceState integration.DState
+	DeviceState DState
 
-	messages chan string
+	Messages chan string
 
 	// Client specific functions
 	// Initialize the client
 	// Here you can add entities if they are already known
-	initFunc func()
+	InitFunc func()
 	// Called by RemoteTwo when the integration is added and setup started
-	setupFunc func(integration.SetupData)
+	SetupFunc func(SetupData)
 	// Handles connect/disconnect calls from RemoteTwo
-	clientLoopFunc        func()
-	setDriverUserDataFunc func(map[string]string, bool)
+	ClientLoopFunc        func()
+	SetDriverUserDataFunc func(map[string]string, bool)
 }
 
-func NewClient(i *integration.Integration) *Client {
+func NewClient(i *Integration) *Client {
 
 	client := Client{}
 
 	client.IntegrationDriver = i
 	// Start without a connection
-	client.DeviceState = integration.DisconnectedDeviceState
+	client.DeviceState = DisconnectedDeviceState
 
-	client.messages = make(chan string)
+	client.Messages = make(chan string)
 
 	return &client
 
@@ -51,33 +49,33 @@ func (c *Client) InitClient() {
 	c.IntegrationDriver.SetHandleSetDriverUserDataFunction(c.HandleSetDriverUserDataFunction)
 
 	// Call setup Function if its set
-	if c.initFunc != nil {
-		c.initFunc()
+	if c.InitFunc != nil {
+		c.InitFunc()
 	}
 }
 
-func (c *Client) HandleConnection(e *integration.ConnectEvent) {
+func (c *Client) HandleConnection(e *ConnectEvent) {
 	switch e.Msg {
 	case "connect":
 		// Only start connecting if in disconnected state or error state
-		if c.DeviceState == integration.DisconnectedDeviceState || c.DeviceState == integration.ErrorDeviceState {
-			c.setDeviceState(integration.ConnectingDeviceState)
+		if c.DeviceState == DisconnectedDeviceState || c.DeviceState == ErrorDeviceState {
+			c.SetDeviceState(ConnectingDeviceState)
 
 			// to make sure event is sent
 			time.Sleep(1 * time.Second)
 
 			// And then connect
-			go c.connect()
+			go c.Connect()
 		} else {
 			// Just send the current state
-			c.setDeviceState(c.DeviceState)
+			c.SetDeviceState(c.DeviceState)
 		}
 
 	case "disconnect":
 
-		if c.DeviceState == integration.ConnectedDeviceState {
+		if c.DeviceState == ConnectedDeviceState {
 			// And disconnect
-			go c.disconnect()
+			go c.Disconnect()
 		}
 
 	}
@@ -85,10 +83,10 @@ func (c *Client) HandleConnection(e *integration.ConnectEvent) {
 
 // Handle Setup called by Remote Two to setup this integration
 // the SetupData are passed to this function
-func (c *Client) HandleSetup(setup_data integration.SetupData) {
+func (c *Client) HandleSetup(setup_data SetupData) {
 
-	if c.setupFunc != nil {
-		c.setupFunc(setup_data)
+	if c.SetupFunc != nil {
+		c.SetupFunc(setup_data)
 	}
 
 }
@@ -104,31 +102,31 @@ func (c *Client) HandleSetDriverUserDataFunction(userdata map[string]string, con
 		"Confim":   confirm,
 	}).Debug(("Handle SetDriverUserData"))
 
-	if c.setDriverUserDataFunc != nil {
-		c.setDriverUserDataFunc(userdata, confirm)
+	if c.SetDriverUserDataFunc != nil {
+		c.SetDriverUserDataFunc(userdata, confirm)
 	}
 
 }
 
-func (c *Client) connect() {
-	c.clientLoop()
+func (c *Client) Connect() {
+	c.ClientLoop()
 }
 
-func (c *Client) disconnect() {
-	c.messages <- "disconnect"
+func (c *Client) Disconnect() {
+	c.Messages <- "disconnect"
 }
 
-func (c *Client) setDeviceState(state integration.DState) {
+func (c *Client) SetDeviceState(state DState) {
 	log.WithField("state", state).Debug("Set device state and send to integration")
 	c.DeviceState = state
 	c.IntegrationDriver.SetDeviceState(c.DeviceState)
 }
 
-func (c *Client) clientLoop() {
+func (c *Client) ClientLoop() {
 	log.Info("Start Client Loop")
 
-	if c.clientLoopFunc != nil {
-		go c.clientLoopFunc()
+	if c.ClientLoopFunc != nil {
+		go c.ClientLoopFunc()
 	} else {
 		log.Fatal("Client loop not implemented")
 	}


### PR DESCRIPTION
Separate clients into its own package and move generic client to the integration package.

BREAKING CHANGE: the client package does not exist anymore and client struct moved to the integration package. You have to change your client implementation.