### PR TITLE
[DenonAVR] Fix Power toggle command

### DIFF
--- a/pkg/denonavr/power.go
+++ b/pkg/denonavr/power.go
@@ -22,10 +22,10 @@ func (d *DenonAVR) TurnOff() error {
 func (d *DenonAVR) TogglePower() error {
 
 	if d.IsOn() {
-		return d.TurnOn()
+		return d.TurnOff()
 	}
 
-	return d.TurnOff()
+	return d.TurnOn()
 }
 
 func (d *DenonAVR) IsOn() bool {


### PR DESCRIPTION
Fixes the power toggle command in the DenonAVR Client. Now when the Device is on, it calls the turnOff command and vice versa.